### PR TITLE
Configurable space indent and conversion to tabs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,28 +1,25 @@
 module.exports = function (eleventyConfig) {
-  eleventyConfig.addNunjucksFilter("formatSnippetBody", function (content) {
+  eleventyConfig.addShortcode("formatSnippetBody", function (content, indent) {
     // escape " and create array of lines
-    const snippet = content.replace(/"/g, '\\"').split("\n");
-    // default indentation
-    // TODO make indent value configurable
-    const indent = 2;
+    const snippet = content.replace(/"/g, '\\"').trim().split("\n");
+    const spaceIndent = indent > 0 ? indent : 2;
     // wrap each line in double quotes
     const formattedSnippet = snippet.map((line, index) => {
-      // count the number of leading spaces or \t chars
-      const indentCount = line.search(/\S/) !== -1 ? line.search(/\S/) : 0;
-      let newLine;
-      // no need to transform if tabs in use vs spaces
+      // if lines are indented with tabs, no need to transform
       if (line.charAt(0) === "\t") {
         return index === snippet.length - 1 ? `"${line}"` : `"${line}",`;
-      } else {
-        // handle space based tabs
-        newLine = line
-          // remove the leading whitespace
-          .trimStart()
-          // add a \t for each tabstop according to indentCount
-          .replace(/^/, "\t".repeat(indentCount / indent));
-        // don't add a comma after the last line
-        return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
       }
+
+      // if lines are indented with spaces, transform to tabs
+      // count the number of leading spaces
+      const indentCount = line.search(/\S/) !== -1 ? line.search(/\S/) : 0;
+      const newLine = line
+        // remove the leading spaces
+        .trimStart()
+        // add a \t for each tabstop according to indentCount
+        .replace(/^/, "\t".repeat(indentCount / spaceIndent));
+      // don't add a comma after the last line
+      return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
     });
 
     return formattedSnippet.join("\n");

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,13 +9,20 @@ module.exports = function (eleventyConfig) {
     const formattedSnippet = snippet.map((line, index) => {
       // count the number of leading spaces or \t chars
       const indentCount = line.search(/\S/) !== -1 ? line.search(/\S/) : 0;
-      const newLine = line
-        // remove the leading whitespace
-        .trimStart()
-        // add a \t for each tabstop according to indentCount
-        .replace(/^/, "\t".repeat(indentCount / indent));
-      // don't add a comma after the last line
-      return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
+      let newLine;
+      // no need to transform if tabs in use vs spaces
+      if (line.charAt(0) === "\t") {
+        return index === snippet.length - 1 ? `"${line}"` : `"${line}",`;
+      } else {
+        // handle space based tabs
+        newLine = line
+          // remove the leading whitespace
+          .trimStart()
+          // add a \t for each tabstop according to indentCount
+          .replace(/^/, "\t".repeat(indentCount / indent));
+        // don't add a comma after the last line
+        return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
+      }
     });
 
     return formattedSnippet.join("\n");

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,10 +2,20 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addNunjucksFilter("formatSnippetBody", function (content) {
     // escape " and create array of lines
     const snippet = content.replace(/"/g, '\\"').split("\n");
+    // default indentation
+    // TODO make indent value configurable
+    const indent = 2;
     // wrap each line in double quotes
     const formattedSnippet = snippet.map((line, index) => {
+      // count the number of leading spaces or \t chars
+      const indentCount = line.search(/\S/) !== -1 ? line.search(/\S/) : 0;
+      const newLine = line
+        // remove the leading whitespace
+        .trimStart()
+        // add a \t for each tabstop according to indentCount
+        .replace(/^/, "\t".repeat(indentCount / indent));
       // don't add a comma after the last line
-      return index === snippet.length - 1 ? `"${line}"` : `"${line}",`;
+      return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
     });
 
     return formattedSnippet.join("\n");

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,21 +3,18 @@ module.exports = function (eleventyConfig) {
     // escape " and create array of lines
     const snippet = content.replace(/"/g, '\\"').trim().split("\n");
     const spaceIndent = indent > 0 ? indent : 2;
-    // wrap each line in double quotes
-    const formattedSnippet = snippet.map((line, index) => {
-      // if lines are indented with tabs, no need to transform
-      if (line.charAt(0) === "\t") {
-        return index === snippet.length - 1 ? `"${line}"` : `"${line}",`;
-      }
 
-      // if lines are indented with spaces, transform to tabs
-      // count the number of leading spaces
+    const formattedSnippet = snippet.map((line, index) => {
+      // count the number of leading whitespace characters (tab or spaces)
       const indentCount = line.search(/\S/) !== -1 ? line.search(/\S/) : 0;
-      const newLine = line
-        // remove the leading spaces
-        .trimStart()
-        // add a \t for each tabstop according to indentCount
-        .replace(/^/, "\t".repeat(indentCount / spaceIndent));
+      let newLine = line;
+
+      if (line.charAt(0) === "\t") {
+        newLine = line.replace(/\t/g, "\\t");
+      } else {
+        // add a \t for each space tab according to indentCount
+        newLine = newLine.trimStart().replace(/^/, "\\t".repeat(indentCount / spaceIndent));
+      }
       // don't add a comma after the last line
       return index === snippet.length - 1 ? `"${newLine}"` : `"${newLine}",`;
     });

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/_includes/vscode-snippet-template.njk
+++ b/_includes/vscode-snippet-template.njk
@@ -6,7 +6,7 @@ permalink: "{{ page.filePathStem }}.json"
     "scope": "{{ scope }}",{% endif %}
     "prefix": "{{ prefix }}",
     "body": [
-      {{ content | trim | formatSnippetBody | safe }}
+      {% formatSnippetBody content, indent %}
     ],
     "description": "{% if description %}{{ description }}{% endif %}"
   }

--- a/_includes/vscode-snippet-template.njk
+++ b/_includes/vscode-snippet-template.njk
@@ -6,7 +6,7 @@ permalink: "{{ page.filePathStem }}.json"
     "scope": "{{ scope }}",{% endif %}
     "prefix": "{{ prefix }}",
     "body": [
-      {{ content | trim | formatSnippetBody | indent(6) | safe }}
+      {{ content | trim | formatSnippetBody | safe }}
     ],
     "description": "{% if description %}{{ description }}{% endif %}"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "snippet-generator",
+  "name": "11ty-vscode-snippet-generator",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "snippet-generator",
+      "name": "11ty-vscode-snippet-generator",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
-        "@11ty/eleventy": "^1.0.0"
+        "@11ty/eleventy": "^1.0.0",
+        "prettier": "^2.5.1"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2544,6 +2545,18 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/pretty": {
       "version": "2.0.0",
@@ -5740,6 +5753,12 @@
           "dev": true
         }
       }
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
     },
     "pretty": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "11ty vscode snippet generator",
   "main": "index.js",
   "scripts": {
-    "build": "npx @11ty/eleventy",
-    "dev": "npx @11ty/eleventy --serve"
+    "build": "npx @11ty/eleventy && npm run prettier",
+    "dev": "npx @11ty/eleventy --serve",
+    "prettier": "npx prettier --write _site/**/*.json"
   },
   "keywords": [
     "11ty",
@@ -16,6 +17,7 @@
   "author": "James Deane",
   "license": "MIT",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.0"
+    "@11ty/eleventy": "^1.0.0",
+    "prettier": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npx @11ty/eleventy && npm run prettier",
     "dev": "npx @11ty/eleventy --serve",
+    "debug": "DEBUG=Eleventy* npx @11ty/eleventy --serve",
     "prettier": "npx prettier --write _site/**/*.json"
   },
   "keywords": [

--- a/src/snippets/snippets.11tydata.js
+++ b/src/snippets/snippets.11tydata.js
@@ -1,0 +1,6 @@
+module.exports = {
+  eleventyComputed: {
+    indent: (data) => data.spaceIndent,
+  },
+  layout: "vscode-snippet-template.njk",
+};

--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -1,3 +1,0 @@
-{
-  "layout": "vscode-snippet-template.njk"
-}

--- a/src/snippets/test-snippet-4-spaces.njk
+++ b/src/snippets/test-snippet-4-spaces.njk
@@ -1,0 +1,17 @@
+---
+name: snippet-name-goes-here
+prefix: badger:4
+description: snippet description goes here
+scope: javascript, typescript
+spaceIndent: 4
+---
+const req = async fetch($1)
+// this is a single line comment
+const res = await req.json()
+const string = "badger" // inline comment test
+for (const item of res) {
+    if (item.name.includes(string)) {
+        console.log(item.name)
+    }
+}
+$0

--- a/src/snippets/test-snippet-tabs.njk
+++ b/src/snippets/test-snippet-tabs.njk
@@ -1,6 +1,6 @@
 ---
 name: snippet-name-goes-here
-prefix: badger
+prefix: badger:tab
 description: snippet description goes here
 scope: javascript, typescript
 ---

--- a/src/snippets/test-snippet-tabs.njk
+++ b/src/snippets/test-snippet-tabs.njk
@@ -9,8 +9,8 @@ const req = async fetch($1)
 const res = await req.json()
 const string = "badger" // inline comment test
 for (const item of res) {
-  if (item.name.includes(string)) {
-    console.log(item.name)
-  }
+	if (item.name.includes(string)) {
+		console.log(item.name)
+	}
 }
 $0


### PR DESCRIPTION
The output of a snippet `body` should print the `\t` character if tabs were used for indentation in the source snippet, however if the source input snippet uses space based indentation conversion is required.

## Input
```
const req = async fetch($1)
// this is a single line comment
const res = await req.json()
const string = "badger" // inline comment test
for (const item of res) {
  if (item.name.includes(string)) {
    console.log(item.name)
  }
}
$0
```

## Output
```
"snippet-name-goes-here": {
  "scope": "javascript, typescript",
  "prefix": "badger",
  "body": [
    "const req = async fetch($1)",
    "// this is a single line comment",
    "const res = await req.json()",
    "const string = \"badger\" // inline comment test",
    "for (const item of res) {",
    "\tif (item.name.includes(string)) {",
    "\t\tconsole.log(item.name)",
    "\t}",
    "}",
    "$0"
  ],
  "description": "snippet description goes here"
}
```

Now using a [shortcode](https://www.11ty.dev/docs/shortcodes/) instead of a [filter](https://www.11ty.dev/docs/filters/).

Fixed #4 